### PR TITLE
Only include aws-keychain-util on Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.gem
 *.rbc
 .bundle

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ Additionally, it supports automatic credential setup for the following libraries
 
 ## Installation
 
-Add the following line to your application's Gemfile.
+Add the following line(s) to your application's Gemfile.
 
     gem 'omnivault'
+
+    # Optional dependency, only works on Mac OS X
+    gem 'aws-keychain-util' 
 
 And then run `bundle install`.
 
@@ -36,7 +39,8 @@ This will determine an appropriate provider using the following logic:
 * If the ENV variable `VAULT` is set, it will use that provider, i.e.,
   - Apple Keychain for `VAULT=apple`
   - PWS for `VAULT=pws`
-* If no ENV variable is set, it will try to use Apple Keychain first, and fall back to PWS if not on Apple OS X.
+* If no ENV variable is set, it will try to use Apple Keychain first on OS X, then PWS. If not on OS X only PWS will be 
+used.
 
 Then, to use Omnivault, you can:
 

--- a/lib/omnivault/abstract_vault.rb
+++ b/lib/omnivault/abstract_vault.rb
@@ -10,7 +10,11 @@ module Omnivault
     end
 
     def self.for_platform
-      AppleKeychain.new
+      if (/darwin/ =~ RUBY_PLATFORM).nil?
+        PWS.new
+      else
+        AppleKeychain.new
+      end
     rescue LoadError
       PWS.new
     end

--- a/lib/omnivault/version.rb
+++ b/lib/omnivault/version.rb
@@ -1,3 +1,3 @@
 module Omnivault
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/omnivault.gemspec
+++ b/omnivault.gemspec
@@ -19,8 +19,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-keychain-util'
   spec.add_dependency 'aws-pws'
+
+  # aws-keychain-util is an optional dependency if using Mac OS X.
+  # spec.add_dependency 'aws-keychain-util'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'aptible-tasks'


### PR DESCRIPTION
Check if the gem is running on Mac OS X before adding dependency,
and change platform default if the plaform is not Mac OS X.

Relates to aptible/primetime#31

cc @fancyremarker 