### PR TITLE
Refactor Omnivault to be primarily a CLI tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,17 @@
-rvm:
-  - "2.1"
+sudo: true
+language: ruby
+cache: bundler
+matrix:
+  include:
+    - os: osx
+      env:
+        - BATS_TEST=test/osx.bats
+    - os: linux
+      env:
+        - BATS_TEST=test/linux.bats
+before_install:
+  - sudo test/install-bats.sh
+script:
+  - bundle exec rake
+  - rake build && gem install pkg/omnivault-*.gem
+  - BUNDLE_GEMFILE= bats $BATS_TEST

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/aptible/omnivault.png?branch=master)](https://travis-ci.org/aptible/omnivault)
 [![Dependency Status](https://gemnasium.com/aptible/omnivault.png)](https://gemnasium.com/aptible/omnivault)
 
-A Ruby library to abstract keychain functionality for storing and retrieiving arbitrary secrets from a variety of password vaults.
+A Ruby library and CLI tool to abstract keychain functionality for storing and retrieiving arbitrary secrets from a variety of password vaults.
 
 Omnivault supports simple key-value secret retrieval with the following password vaults:
 
@@ -15,18 +15,29 @@ Additionally, it supports automatic credential setup for the following libraries
 
 * AWS Ruby SDK (`aws-sdk-v1`, `aws-sdk`)
 
-## Installation
+## Installation and Usage (CLI Tool)
+
+To install for CLI usage, simply run `gem install omnivault` and then refer to `omnivault help` for usage:
+
+```
+Commands:
+  omnivault env [-v VAULT]                                # Print secret values from vault as source-able ENV variables
+  omnivault exec [-v VAULT] COMMAND                       # Execute command with secret values as ENV variables
+  omnivault help [COMMAND]                                # Describe available commands or one specific command
+  omnivault ls [-v VAULT]                                 # List all secret keys from vault
+  omnivault set [-v VAULT] KEY1=value1 [KEY2=value2 ...]  # Set one or more secret values in vault
+  omnivault unset [-v VAULT] KEY1 [KEY2 ...]              # Unset one or more secret values in vault
+```
+
+## Installation (Library)
 
 Add the following line(s) to your application's Gemfile.
 
     gem 'omnivault'
 
-    # Optional dependency, only works on Mac OS X
-    gem 'aws-keychain-util' 
-
 And then run `bundle install`.
 
-## Usage
+## Usage (Library)
 
 To initialize the the Omnivault, run:
 
@@ -39,7 +50,7 @@ This will determine an appropriate provider using the following logic:
 * If the ENV variable `VAULT` is set, it will use that provider, i.e.,
   - Apple Keychain for `VAULT=apple`
   - PWS for `VAULT=pws`
-* If no ENV variable is set, it will try to use Apple Keychain first on OS X, then PWS. If not on OS X only PWS will be 
+* If no ENV variable is set, it will try to use Apple Keychain first on OS X, then PWS. If not on OS X only PWS will be
 used.
 
 Then, to use Omnivault, you can:
@@ -60,51 +71,12 @@ Omnivault provides a `configure_aws!` method, which can be used to automatically
 omnivault.configure_aws!
 ```
 
-To use this feature, you'll need to set up `aws-keychain-util` or `aws-pws`. With either approach, you can also (optionally) create a new `aws` shell command which wraps the original [AWS CLI](https://aws.amazon.com/cli/) to provide authenticated access to your AWS credentials.
+To use this feature, you'll need to set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets in Omnivault:
 
-### Apple Keychain
+```
+omnivault set AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+```
 
-To set up AWS credentials using `aws-keychain-util`:
-
-1. `gem install -N aws-keychain-util`
-2. `aws-creds init`
-3. `aws-creds add`
-
-    - Use 'default' for the account name
-    - Leave the MFA ARN blank
-
-4. (Optional) Add the following file as `aws` somewhere on your `PATH` with higher precedence than `/usr/local/bin`. (`$HOME/.bin` is a good choice.) Make it executable by running `chmod +x aws-safe`.
-
-        #!/bin/bash
-        # $HOME/.bin/aws
-
-        set -e
-
-        export $(aws-creds cat default)
-        /usr/local/bin/aws $@
-
-
-### PWS
-
-On Linux, you can use PWS instead:
-
-1. `gem install -N aws-pws`
-2. `aws-pws init`
-3. (Optional) Add the following file as `aws` somewhere on your `PATH` with higher precedence than `/usr/local/bin`.
-
-        #!/bin/bash
-        # $HOME/.bin/aws
-
-        set -e
-
-        export $(aws-pws cat)
-        /usr/local/bin/aws $@
-
-## TODO
-
-* Add support for 1Password keychains.
-* Write RSpec unit tests.
-* Remove dependence on AWS-specific gems directly
 
 ## Contributing
 
@@ -117,6 +89,6 @@ On Linux, you can use PWS instead:
 
 MIT License, see [LICENSE](LICENSE.md) for details.
 
-Copyright (c) 2015 [Aptible](https://www.aptible.com), Frank Macreery, and contributors.
+Copyright (c) 2017 [Aptible](https://www.aptible.com), Frank Macreery, and contributors.
 
 [<img src="https://s.gravatar.com/avatar/f7790b867ae619ae0496460aa28c5861?s=60" style="border-radius: 50%;" alt="@fancyremarker" />](https://github.com/fancyremarker)

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,8 @@
 require 'bundler/gem_tasks'
 
-require 'aptible/tasks'
-Aptible::Tasks.load_tasks
+begin
+  require 'aptible/tasks'
+  Aptible::Tasks.load_tasks
+rescue LoadError
+  task :default
+end

--- a/bin/omnivault
+++ b/bin/omnivault
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+begin
+  require 'omnivault/cli'
+rescue
+  require 'rubygems'
+  require 'omnivault/cli'
+end
+
+Omnivault::CLI.start

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,17 @@
+require 'rubygems'
+require 'rubygems/command'
+require 'rubygems/dependency_installer'
+
+begin
+  Gem::Command.build_args = ARGV
+rescue NoMethodError
+end
+
+inst = Gem::DependencyInstaller.new
+begin
+  inst.install 'ruby-keychain' if RbConfig::CONFIG['host_os'] =~ /darwin/
+rescue => e
+  puts e.message
+  puts e.backtrace
+  exit 1
+end

--- a/lib/omnivault.rb
+++ b/lib/omnivault.rb
@@ -5,7 +5,8 @@ require_relative 'omnivault/apple_keychain'
 require_relative 'omnivault/pws'
 
 module Omnivault
-  def self.autodetect
-    Omnivault::AbstractVault.from_env || Omnivault::AbstractVault.for_platform
+  def self.autodetect(name = 'default')
+    Omnivault::AbstractVault.from_env(name) ||
+      Omnivault::AbstractVault.for_platform(name)
   end
 end

--- a/lib/omnivault/abstract_vault.rb
+++ b/lib/omnivault/abstract_vault.rb
@@ -1,22 +1,62 @@
 module Omnivault
   class AbstractVault
-    def self.from_env
+    def self.from_env(name = 'default')
       case ENV['VAULT']
-      when 'apple', 'AppleKeychain'
-        AppleKeychain.new
+      when 'apple', 'keychain', 'AppleKeychain'
+        AppleKeychain.new(name)
       when 'pws', 'PWS'
-        PWS.new
+        PWS.new(name)
       end
     end
 
-    def self.for_platform
+    def self.for_platform(name = 'default')
       if (/darwin/ =~ RUBY_PLATFORM).nil?
-        PWS.new
+        PWS.new(name)
       else
-        AppleKeychain.new
+        AppleKeychain.new(name)
       end
-    rescue LoadError
-      PWS.new
+    rescue LoadError => e
+      puts e.message
+      puts e.backtrace
+      PWS.new(name)
+    end
+
+    # Either aws-sdk and/or aws-sdk-v1 must be required BEFORE calling
+    # Omnivault::AbstractVault#configure_aws!
+    def configure_aws!
+      if defined?(Aws)
+        require_relative 'v2_credential_provider'
+
+        provider = V2CredentialProvider.new(self)
+        Aws.config[:credentials] = provider
+      end
+
+      if defined?(AWS)
+        require_relative 'v1_credential_provider'
+
+        provider = V1CredentialProvider.new(self)
+        AWS.config(credential_provider: provider)
+      end
+    end
+
+    def initialize(_name = 'default')
+      raise NotImplementedError, 'Must invoke from subclass'
+    end
+
+    def entries
+      raise NotImplementedError, 'Must invoke from subclass'
+    end
+
+    def fetch(key)
+      entries[key]
+    end
+
+    def store(_key, _value)
+      raise NotImplementedError, 'Must invoke from subclass'
+    end
+
+    def remove(_key)
+      raise NotImplementedError, 'Must invoke from subclass'
     end
   end
 end

--- a/lib/omnivault/cli.rb
+++ b/lib/omnivault/cli.rb
@@ -1,0 +1,83 @@
+require 'thor'
+require 'omnivault'
+require 'shellwords'
+
+module Omnivault
+  class CLI < Thor
+    include Thor::Actions
+
+    # Forward return codes on failures.
+    def self.exit_on_failure?
+      true
+    end
+
+    def self.default_options
+      option :vault, aliases: '-v', default: 'default'
+    end
+
+    def self.default_option_desc
+      '[-v VAULT]'
+    end
+
+    desc "set #{default_option_desc} KEY1=value1 [KEY2=value2 ...]",
+         'Set one or more secret values in vault'
+    default_options
+    def set(*args)
+      raise ArgumentError, 'Wrong number of arguments' if args.empty?
+
+      hash = Hash[args.map { |arg| arg.split('=', 2) }]
+      hash.each do |key, value|
+        vault_by_name(options[:vault]).store(key, value)
+      end
+    end
+
+    desc "unset #{default_option_desc} KEY1 [KEY2 ...]",
+         'Unset one or more secret values in vault'
+    default_options
+    def unset(*args)
+      raise ArgumentError, 'Wrong number of arguments' if args.empty?
+
+      vault = vault_by_name(options[:vault])
+      missing = args - vault.entries.keys
+      raise Thor::Error, "Keys not found: #{missing.join(', ')}" if missing.any?
+      args.each do |key|
+        vault.remove(key)
+      end
+    end
+
+    desc "env #{default_option_desc}",
+         'Print secret values from vault as source-able ENV variables'
+    default_options
+    def env
+      vault_by_name(options[:vault]).entries.each do |key, value|
+        say "#{key}=#{Shellwords.escape(value)}"
+      end
+    end
+
+    desc "exec #{default_option_desc} COMMAND",
+         'Execute command with secret values as ENV variables'
+    default_options
+    def exec(*args)
+      vault_by_name(options[:vault]).entries.each do |key, value|
+        ENV[key] = value
+      end
+      system(*args)
+    end
+
+    desc "ls #{default_option_desc}",
+         'List all secret keys from vault'
+    default_options
+    def ls
+      vault_by_name(options[:vault]).entries.keys.each do |key|
+        say key
+      end
+    end
+
+    private
+
+    def vault_by_name(name)
+      @vaults ||= {}
+      @vaults[name] ||= Omnivault.autodetect(name)
+    end
+  end
+end

--- a/lib/omnivault/pws.rb
+++ b/lib/omnivault/pws.rb
@@ -1,27 +1,24 @@
-require 'aws/pws'
-require 'aws/pws/credential_provider'
-
 module Omnivault
   class PWS < AbstractVault
-    attr_accessor :client
+    attr_accessor :cli, :raw_data
 
-    def entries
-      @client ||= AWS::PWS::Client.new
-      Hash[@client.raw_data.map { |k, v| [k, v[:password]] }]
+    def initialize(name = 'default')
+      require 'pws'
+
+      @cli ||= ::PWS.new(namespace: name)
+      @raw_data = @cli.instance_variable_get(:@data)
     end
 
-    def fetch(key)
-      entries[key]
+    def entries
+      Hash[raw_data.map { |k, v| [k, v[:password]] }]
     end
 
     def store(key, value)
-      @client ||= AWS::PWS::Client.new
-      @client.cli.add(key, value)
+      cli.add(key, value)
     end
 
-    def configure_aws!
-      provider = AWS::PWS::CredentialProvider.new
-      AWS.config(credential_provider: provider)
+    def remove(key)
+      cli.remove(key)
     end
   end
 end

--- a/lib/omnivault/v1_credential_provider.rb
+++ b/lib/omnivault/v1_credential_provider.rb
@@ -1,0 +1,22 @@
+require 'aws-sdk-v1'
+
+module Omnivault
+  class V1CredentialProvider
+    include AWS::Core::CredentialProviders::Provider
+
+    attr_accessor :vault
+
+    def initialize(vault)
+      @vault = vault
+    end
+
+    # rubocop:disable AccessorMethodName
+    def get_credentials
+      {
+        access_key_id: vault.fetch('AWS_ACCESS_KEY_ID'),
+        secret_access_key: vault.fetch('AWS_SECRET_ACCESS_KEY')
+      }
+    end
+    # rubocop:enable AccessorMethodName
+  end
+end

--- a/lib/omnivault/v2_credential_provider.rb
+++ b/lib/omnivault/v2_credential_provider.rb
@@ -1,0 +1,18 @@
+require 'aws-sdk'
+
+module Omnivault
+  class V2CredentialProvider
+    include Aws::CredentialProvider
+
+    attr_accessor :vault
+
+    def initialize(vault)
+      @vault = vault
+    end
+
+    def credentials
+      Aws::Credentials.new(vault.fetch('AWS_ACCESS_KEY_ID'),
+                           vault.fetch('AWS_SECRET_ACCESS_KEY'))
+    end
+  end
+end

--- a/lib/omnivault/version.rb
+++ b/lib/omnivault/version.rb
@@ -1,3 +1,3 @@
 module Omnivault
-  VERSION = '0.1.2'
+  VERSION = '0.2.0'.freeze
 end

--- a/omnivault.gemspec
+++ b/omnivault.gemspec
@@ -16,16 +16,19 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($RS)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
+  spec.extensions = 'ext/mkrf_conf.rb'
 
-  spec.add_dependency 'aws-pws'
-
-  # aws-keychain-util is an optional dependency if using Mac OS X.
-  # spec.add_dependency 'aws-keychain-util'
+  spec.add_dependency 'thor'
+  spec.add_dependency 'pws'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'aptible-tasks'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.0'
+  spec.add_development_dependency 'aws-sdk', '~> 2'
+  spec.add_development_dependency 'aws-sdk-v1'
+  spec.add_development_dependency 'pry'
 end

--- a/spec/omnivault/abstract_vault_spec.rb
+++ b/spec/omnivault/abstract_vault_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Omnivault::AbstractVault do
+  before do
+    # Override parent class initialization exception in tests
+    described_class.send(:define_method, :initialize) {}
+  end
+
+  describe '#configure_aws!' do
+    before do
+      allow(subject).to receive(:entries) do
+        {
+          'AWS_ACCESS_KEY_ID' => 'id',
+          'AWS_SECRET_ACCESS_KEY' => 'secret'
+        }
+      end
+    end
+
+    it 'configures credentials for aws-sdk-v1' do
+      require 'aws-sdk-v1'
+      subject.configure_aws!
+      v1_credentials = AWS.config.credential_provider.credentials
+      expect(v1_credentials[:access_key_id]).to eq 'id'
+      expect(v1_credentials[:secret_access_key]).to eq 'secret'
+    end
+
+    it 'configures credentials for aws-sdk-v2' do
+      require 'aws-sdk'
+      subject.configure_aws!
+
+      v2_credentials = Aws.config[:credentials].credentials
+      expect(v2_credentials.access_key_id).to eq 'id'
+      expect(v2_credentials.secret_access_key).to eq 'secret'
+    end
+  end
+end

--- a/test/install-bats.sh
+++ b/test/install-bats.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd /tmp
+git clone https://github.com/sstephenson/bats.git
+cd bats/
+./install.sh /usr/local
+cd ..
+rm -rf bats/

--- a/test/linux.bats
+++ b/test/linux.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+  echo 'foobar
+foobar' | pws -bats add FOO bar
+}
+
+teardown() {
+  rm -f $HOME/.pws-bats
+}
+
+@test "It should install the ruby-keychain gem" {
+  run gem list ruby-keychain
+  [[ ! "$output" =~ "ruby-keychain" ]]
+}
+
+@test "It should print secrets via omnivault env" {
+  run bash -c "echo foobar | omnivault env -v bats"
+  echo $output > $HOME/bats.out
+  [[ "$output" =~ "FOO=bar" ]]
+}
+
+@test "It should run a shell with secrets in ENV via omnivault exec" {
+  run bash -c "echo foobar | omnivault exec -v bats env"
+  [[ "$output" =~ "FOO=bar" ]]
+}

--- a/test/osx.bats
+++ b/test/osx.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+  security create-keychain -p foobar omnivault-bats.keychain
+  security add-generic-password -A -a FOO -s FOO -w bar omnivault-bats.keychain
+  security unlock-keychain -p foobar omnivault-bats.keychain
+}
+
+teardown() {
+  rm -f $HOME/Library/Keychains/omnivault-bats.keychain
+}
+
+@test "It should install the ruby-keychain gem" {
+  run gem list ruby-keychain
+  [[ "$output" =~ "ruby-keychain" ]]
+}
+
+@test "It should print secrets via omnivault env" {
+  run omnivault env -v bats
+  [[ "$output" =~ "FOO=bar" ]]
+}
+
+@test "It should run a shell with secrets in ENV via omnivault exec" {
+  run omnivault exec -v bats env
+  [[ "$output" =~ "FOO=bar" ]]
+}


### PR DESCRIPTION
...while retaining support for `vault.configure_aws!` library method.

* Remove dependency on other AWS-specific vault gems (aws-keychain-util and aws-pws), referencing the underlying pws and ruby-keychain library methods directly.
* Add CLI for basic vault functions: add, remove, ls, env, and exec.
* Conditionally install ruby-keychain gem only on OS X, via gem build extension.
* Add unit tests for `vault.configure_aws!` method.
* Add integration tests for proper integration w/ Keychain on OS X, and pws on Linux.